### PR TITLE
chore: update nvm for build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
 
 # To enable semantic-release, uncomment these sections.
 before_deploy:
-  - nvm install 14
+  - nvm install 18
   - npm install -g npm@6.x
   - npm install @semantic-release/changelog
   - npm install @semantic-release/exec


### PR DESCRIPTION
Signed-off-by: Nitish Kulkarni <nitish.kulkarni3@ibm.com>

## PR summary
build was failing due to node version >=18 is required. Found v14.21.2.

**Fixes:** <! -- [link to issue](https://github.ibm.com/Notification-Hub/planning/issues/6640) -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Go Commit Message Guidelines](https://github.com/IBM/ibm-cloud-sdk-common/blob/main/CONTRIBUTING_go.md#commit-messages).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
travis build file was having nvm 14 

## What is the new behavior?  
updated to the latest 18 for build issue fix

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->