### PR TITLE
chore: slack attribute fix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-28T08:42:35Z",
+  "generated_at": "2023-04-10T04:11:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -118,7 +118,7 @@
         "hashed_secret": "e8e75379ccc030eb8ec988a993ef3c6e6cbd9c98",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 178,
+        "line_number": 179,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -126,7 +126,7 @@
         "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 562,
+        "line_number": 563,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -134,7 +134,7 @@
         "hashed_secret": "76093020087344732c40421926f0a97a6cccc17e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1251,
+        "line_number": 1252,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/eventnotificationsv1/event_notifications_v1.go
+++ b/eventnotificationsv1/event_notifications_v1.go
@@ -7596,7 +7596,7 @@ func UnmarshalSubscriptionAttributesServiceNowAttributesResponse(m map[string]js
 // This model "extends" SubscriptionAttributes
 type SubscriptionAttributesSlackAttributesResponse struct {
 	// Attachment Color for Slack Notification.
-	AttachmentColor *string `json:"attachment_color" validate:"required"`
+	AttachmentColor *string `json:"attachment_color,omitempty"`
 
 	// Allows users to set arbitrary properties
 	additionalProperties map[string]interface{}
@@ -7898,16 +7898,7 @@ func UnmarshalSubscriptionCreateAttributesServiceNowAttributes(m map[string]json
 // This model "extends" SubscriptionCreateAttributes
 type SubscriptionCreateAttributesSlackAttributes struct {
 	// Attachment Color for the slack message.
-	AttachmentColor *string `json:"attachment_color" validate:"required"`
-}
-
-// NewSubscriptionCreateAttributesSlackAttributes : Instantiate SubscriptionCreateAttributesSlackAttributes (Generic Model Constructor)
-func (*EventNotificationsV1) NewSubscriptionCreateAttributesSlackAttributes(attachmentColor string) (_model *SubscriptionCreateAttributesSlackAttributes, err error) {
-	_model = &SubscriptionCreateAttributesSlackAttributes{
-		AttachmentColor: core.StringPtr(attachmentColor),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
+	AttachmentColor *string `json:"attachment_color,omitempty"`
 }
 
 func (*SubscriptionCreateAttributesSlackAttributes) isaSubscriptionCreateAttributes() bool {
@@ -8101,16 +8092,7 @@ func UnmarshalSubscriptionUpdateAttributesServiceNowAttributes(m map[string]json
 // This model "extends" SubscriptionUpdateAttributes
 type SubscriptionUpdateAttributesSlackAttributes struct {
 	// Attachment Color for the slack message.
-	AttachmentColor *string `json:"attachment_color" validate:"required"`
-}
-
-// NewSubscriptionUpdateAttributesSlackAttributes : Instantiate SubscriptionUpdateAttributesSlackAttributes (Generic Model Constructor)
-func (*EventNotificationsV1) NewSubscriptionUpdateAttributesSlackAttributes(attachmentColor string) (_model *SubscriptionUpdateAttributesSlackAttributes, err error) {
-	_model = &SubscriptionUpdateAttributesSlackAttributes{
-		AttachmentColor: core.StringPtr(attachmentColor),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
+	AttachmentColor *string `json:"attachment_color,omitempty"`
 }
 
 func (*SubscriptionUpdateAttributesSlackAttributes) isaSubscriptionUpdateAttributes() bool {

--- a/eventnotificationsv1/event_notifications_v1_examples_test.go
+++ b/eventnotificationsv1/event_notifications_v1_examples_test.go
@@ -75,6 +75,7 @@ var (
 	subscriptionID2           string
 	subscriptionID3           string
 	subscriptionID4           string
+	subscriptionID5           string
 	fcmServerKey              string
 	fcmSenderId               string
 	integrationId             string
@@ -1507,6 +1508,27 @@ var _ = Describe(`EventNotificationsV1 Examples Tests`, func() {
 			Expect(subscription).ToNot(BeNil())
 			subscriptionID4 = string(*subscription.ID)
 
+			subscriptionCreateSlackAttributesModel := &eventnotificationsv1.SubscriptionCreateAttributesSlackAttributes{
+				AttachmentColor: core.StringPtr("#0000FF"),
+			}
+
+			createSlackSubscriptionOptions := &eventnotificationsv1.CreateSubscriptionOptions{
+				InstanceID:    core.StringPtr(instanceID),
+				Name:          core.StringPtr("Slack subscription"),
+				Description:   core.StringPtr("Subscription for the Slack"),
+				DestinationID: core.StringPtr(destinationID4),
+				TopicID:       core.StringPtr(topicID),
+				Attributes:    subscriptionCreateSlackAttributesModel,
+			}
+
+			subscription, response, err = eventNotificationsService.CreateSubscription(createSlackSubscriptionOptions)
+			b, _ = json.MarshalIndent(subscription, "", "  ")
+			fmt.Println(string(b))
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(201))
+			Expect(subscription).ToNot(BeNil())
+			subscriptionID5 = string(*subscription.ID)
+
 			// end-create_subscription
 
 		})
@@ -1718,6 +1740,33 @@ var _ = Describe(`EventNotificationsV1 Examples Tests`, func() {
 			Expect(subscription.Name).To(Equal(serviceNowName))
 			Expect(subscription.Description).To(Equal(serviceNowDescription))
 
+			subscriptionUpdateSlackAttributesModel := &eventnotificationsv1.SubscriptionUpdateAttributesSlackAttributes{
+				AttachmentColor: core.StringPtr("#0000FF"),
+			}
+
+			slackName := core.StringPtr("subscription_slack_update")
+			slackDescription := core.StringPtr("Subscription update for slack")
+			updateSlackSubscriptionOptions := &eventnotificationsv1.UpdateSubscriptionOptions{
+				InstanceID:  core.StringPtr(instanceID),
+				Name:        slackName,
+				Description: slackDescription,
+				ID:          core.StringPtr(subscriptionID5),
+				Attributes:  subscriptionUpdateSlackAttributesModel,
+			}
+
+			subscription, response, err = eventNotificationsService.UpdateSubscription(updateSlackSubscriptionOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ = json.MarshalIndent(subscription, "", "  ")
+			fmt.Println(string(b))
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(subscription).ToNot(BeNil())
+			Expect(subscription.ID).To(Equal(core.StringPtr(subscriptionID5)))
+			Expect(subscription.Name).To(Equal(slackName))
+			Expect(subscription.Description).To(Equal(slackDescription))
 			// end-update_subscription
 
 		})
@@ -1893,7 +1942,7 @@ var _ = Describe(`EventNotificationsV1 Examples Tests`, func() {
 				fmt.Printf("\nUnexpected response status code received from DeleteSubscription(): %d\n", response.StatusCode)
 			}
 
-			for _, ID := range []string{subscriptionID1, subscriptionID2, subscriptionID3} {
+			for _, ID := range []string{subscriptionID1, subscriptionID2, subscriptionID3, subscriptionID4, subscriptionID5} {
 
 				deleteSubscriptionOptions := &eventnotificationsv1.DeleteSubscriptionOptions{
 					InstanceID: core.StringPtr(instanceID),

--- a/eventnotificationsv1/event_notifications_v1_integration_test.go
+++ b/eventnotificationsv1/event_notifications_v1_integration_test.go
@@ -1587,12 +1587,17 @@ var _ = Describe(`EventNotificationsV1 Integration Tests`, func() {
 			Expect(subscription).ToNot(BeNil())
 			subscriptionID3 = string(*subscription.ID)
 
+			subscriptionCreateSlackAttributesModel := &eventnotificationsv1.SubscriptionCreateAttributesSlackAttributes{
+				AttachmentColor: core.StringPtr("#0000FF"),
+			}
+
 			createSlackSubscriptionOptions := &eventnotificationsv1.CreateSubscriptionOptions{
 				InstanceID:    core.StringPtr(instanceID),
 				Name:          core.StringPtr("Slack subscription"),
 				Description:   core.StringPtr("Subscription for the Slack"),
 				DestinationID: core.StringPtr(destinationID4),
 				TopicID:       core.StringPtr(topicID),
+				Attributes:    subscriptionCreateSlackAttributesModel,
 			}
 
 			subscription, response, err = eventNotificationsService.CreateSubscription(createSlackSubscriptionOptions)
@@ -1974,6 +1979,10 @@ var _ = Describe(`EventNotificationsV1 Integration Tests`, func() {
 			Expect(subscription.Name).To(Equal(fcmName))
 			Expect(subscription.Description).To(Equal(fcmDescription))
 
+			subscriptionUpdateSlackAttributesModel := &eventnotificationsv1.SubscriptionUpdateAttributesSlackAttributes{
+				AttachmentColor: core.StringPtr("#0000FF"),
+			}
+
 			slackName := core.StringPtr("subscription_slack_update")
 			slackDescription := core.StringPtr("Subscription update for slack")
 			updateSlackSubscriptionOptions := &eventnotificationsv1.UpdateSubscriptionOptions{
@@ -1981,6 +1990,7 @@ var _ = Describe(`EventNotificationsV1 Integration Tests`, func() {
 				Name:        slackName,
 				Description: slackDescription,
 				ID:          core.StringPtr(subscriptionID4),
+				Attributes:  subscriptionUpdateSlackAttributesModel,
 			}
 
 			subscription, response, err = eventNotificationsService.UpdateSubscription(updateSlackSubscriptionOptions)

--- a/eventnotificationsv1/event_notifications_v1_test.go
+++ b/eventnotificationsv1/event_notifications_v1_test.go
@@ -8454,12 +8454,6 @@ var _ = Describe(`EventNotificationsV1`, func() {
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
-			It(`Invoke NewSubscriptionCreateAttributesSlackAttributes successfully`, func() {
-				attachmentColor := "testString"
-				_model, err := eventNotificationsService.NewSubscriptionCreateAttributesSlackAttributes(attachmentColor)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
 			It(`Invoke NewSubscriptionCreateAttributesWebhookAttributes successfully`, func() {
 				signingEnabled := true
 				_model, err := eventNotificationsService.NewSubscriptionCreateAttributesWebhookAttributes(signingEnabled)
@@ -8472,12 +8466,6 @@ var _ = Describe(`EventNotificationsV1`, func() {
 				replyToName := "testString"
 				fromName := "testString"
 				_model, err := eventNotificationsService.NewSubscriptionUpdateAttributesEmailUpdateAttributes(addNotificationPayload, replyToMail, replyToName, fromName)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewSubscriptionUpdateAttributesSlackAttributes successfully`, func() {
-				attachmentColor := "testString"
-				_model, err := eventNotificationsService.NewSubscriptionUpdateAttributesSlackAttributes(attachmentColor)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})


### PR DESCRIPTION
## PR summary
At the time of subscription creation of slack, attribute attachment_color was made as mandatory which is required to be optional.

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/8059

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Go Commit Message Guidelines](https://github.com/IBM/ibm-cloud-sdk-common/blob/main/CONTRIBUTING_go.md#commit-messages).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
attribute attachment_color was made as mandatory which is required to be optional for slack subscription.

## What is the new behavior?  
attribute attachment_color is made optional.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->