### PR TITLE
chore: add custom domain email support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-07-25T16:15:07Z",
+  "generated_at": "2023-08-02T10:55:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -170,7 +170,7 @@
         "hashed_secret": "b8473b86d4c2072ca9b08bd28e373e8253e865c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8602,
+        "line_number": 8843,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ SDK Methods to consume
 	- [Get Destination](#get-destination)
 	- [Update Destination](#update-destination)
 	- [Delete Destination](#delete-destination)
+	- [Custom Domain_Name_verification](#custom-domain-name-verification)
 - [Push Destination APIs](#push-destination-apis)
 	- [Create Destination tag subscription](#create-destination-tag-subscription)
 	- [List Destination tag subscription](#list-destination-tag-subscription)
@@ -446,6 +447,26 @@ deleteDestinationOptions := eventNotificationsService.NewDeleteDestinationOption
 )
 
 response, err := eventNotificationsService.DeleteDestination(deleteDestinationOptions)
+
+if err != nil {
+	panic(err)
+}
+```
+### Custom Domain Name Verification
+
+After creation of the custom email destination with your domain name, make sure its validated for the right ownership. This can be done with SPF and DKIM verification.
+
+* Sender Policy Framework (SPF), which is used to authenticate the sender of an email. SPF specifies the mail servers that are allowed to send email for your domain.
+* DomainKeys Identified Mail (DKIM), which allows an organization to take responsibility for transmitting a message by signing it. DKIM allows the receiver to check the email that claimed to have come from a specific domain, is authorized by the owner of that domain.
+
+```go
+customSpfDkimUpdateDestinationOptions := &eventnotificationsv1.UpdateVerifyDestinationOptions{
+	InstanceID: core.StringPtr(<instance-id>),       // Event notifications service instance GUID
+	ID:         core.StringPtr(<destination-id>),	 // Event notifications service instance Destination ID
+	Type:       core.StringPtr(<verification-type>), // verification type spf/dkim
+}
+
+result, response, err := eventNotificationsService.UpdateVerifyDestination(customSpfUpdateDestinationOptions)
 
 if err != nil {
 	panic(err)

--- a/eventnotificationsv1/event_notifications_v1.go
+++ b/eventnotificationsv1/event_notifications_v1.go
@@ -1351,6 +1351,69 @@ func (eventNotifications *EventNotificationsV1) DeleteDestinationWithContext(ctx
 	return
 }
 
+// UpdateVerifyDestination : Verify status of spf or dkim records of custom email
+// Verify status of spf or dkim records of custom email.
+func (eventNotifications *EventNotificationsV1) UpdateVerifyDestination(updateVerifyDestinationOptions *UpdateVerifyDestinationOptions) (result *VerificationResponse, response *core.DetailedResponse, err error) {
+	return eventNotifications.UpdateVerifyDestinationWithContext(context.Background(), updateVerifyDestinationOptions)
+}
+
+// UpdateVerifyDestinationWithContext is an alternate form of the UpdateVerifyDestination method which supports a Context parameter
+func (eventNotifications *EventNotificationsV1) UpdateVerifyDestinationWithContext(ctx context.Context, updateVerifyDestinationOptions *UpdateVerifyDestinationOptions) (result *VerificationResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(updateVerifyDestinationOptions, "updateVerifyDestinationOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(updateVerifyDestinationOptions, "updateVerifyDestinationOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"instance_id": *updateVerifyDestinationOptions.InstanceID,
+		"id":          *updateVerifyDestinationOptions.ID,
+	}
+
+	builder := core.NewRequestBuilder(core.PATCH)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = eventNotifications.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(eventNotifications.Service.Options.URL, `/v1/instances/{instance_id}/destinations/{id}/verify`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range updateVerifyDestinationOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("event_notifications", "V1", "UpdateVerifyDestination")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	builder.AddQuery("type", fmt.Sprint(*updateVerifyDestinationOptions.Type))
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = eventNotifications.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalVerificationResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
 // CreateTagsSubscription : Create a new tag subscription
 // Create a new tag subscription.
 func (eventNotifications *EventNotificationsV1) CreateTagsSubscription(createTagsSubscriptionOptions *CreateTagsSubscriptionOptions) (result *DestinationTagsSubscriptionResponse, response *core.DetailedResponse, err error) {
@@ -6862,6 +6925,78 @@ func (_options *UpdateSubscriptionOptions) SetAttributes(attributes Subscription
 func (options *UpdateSubscriptionOptions) SetHeaders(param map[string]string) *UpdateSubscriptionOptions {
 	options.Headers = param
 	return options
+}
+
+// UpdateVerifyDestinationOptions : The UpdateVerifyDestination options.
+type UpdateVerifyDestinationOptions struct {
+	// Unique identifier for IBM Cloud Event Notifications instance.
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
+	// Unique identifier for Destination.
+	ID *string `json:"id" validate:"required,ne="`
+
+	// Verification type.
+	Type *string `json:"type" validate:"required"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewUpdateVerifyDestinationOptions : Instantiate UpdateVerifyDestinationOptions
+func (*EventNotificationsV1) NewUpdateVerifyDestinationOptions(instanceID string, id string, typeVar string) *UpdateVerifyDestinationOptions {
+	return &UpdateVerifyDestinationOptions{
+		InstanceID: core.StringPtr(instanceID),
+		ID:         core.StringPtr(id),
+		Type:       core.StringPtr(typeVar),
+	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *UpdateVerifyDestinationOptions) SetInstanceID(instanceID string) *UpdateVerifyDestinationOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
+// SetID : Allow user to set ID
+func (_options *UpdateVerifyDestinationOptions) SetID(id string) *UpdateVerifyDestinationOptions {
+	_options.ID = core.StringPtr(id)
+	return _options
+}
+
+// SetType : Allow user to set Type
+func (_options *UpdateVerifyDestinationOptions) SetType(typeVar string) *UpdateVerifyDestinationOptions {
+	_options.Type = core.StringPtr(typeVar)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *UpdateVerifyDestinationOptions) SetHeaders(param map[string]string) *UpdateVerifyDestinationOptions {
+	options.Headers = param
+	return options
+}
+
+// VerificationResponse : Destination verification object.
+type VerificationResponse struct {
+	// verification type.
+	Type *string `json:"type" validate:"required"`
+
+	// verification status.
+	Verification *string `json:"verification" validate:"required"`
+}
+
+// UnmarshalVerificationResponse unmarshals an instance of VerificationResponse from the specified map of raw messages.
+func UnmarshalVerificationResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(VerificationResponse)
+	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "verification", &obj.Verification)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
 }
 
 // DestinationConfigOneOfChromeDestinationConfig : Payload describing a Chrome destination configuration.

--- a/eventnotificationsv1/event_notifications_v1_examples_test.go
+++ b/eventnotificationsv1/event_notifications_v1_examples_test.go
@@ -1606,6 +1606,23 @@ var _ = Describe(`EventNotificationsV1 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(destination).ToNot(BeNil())
+
+			customEmailUpdateDestinationOptions := &eventnotificationsv1.UpdateVerifyDestinationOptions{
+				InstanceID: core.StringPtr(instanceID),
+				ID:         core.StringPtr(destinationID16),
+				Type:       core.StringPtr("spf/dkim"),
+			}
+
+			spfDkimResult, response, err := eventNotificationsService.UpdateVerifyDestination(customEmailUpdateDestinationOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ = json.MarshalIndent(spfDkimResult, "", "  ")
+			fmt.Println(string(b))
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(spfDkimResult).ToNot(BeNil())
 			// end-update_destination
 		})
 

--- a/eventnotificationsv1/event_notifications_v1_integration_test.go
+++ b/eventnotificationsv1/event_notifications_v1_integration_test.go
@@ -1685,6 +1685,29 @@ var _ = Describe(`EventNotificationsV1 Integration Tests`, func() {
 			Expect(customDestination.ID).To(Equal(core.StringPtr(destinationID16)))
 			Expect(customDestination.Name).To(Equal(core.StringPtr(customName)))
 			Expect(customDestination.Description).To(Equal(core.StringPtr(customDescription)))
+
+			customSpfUpdateDestinationOptions := &eventnotificationsv1.UpdateVerifyDestinationOptions{
+				InstanceID: core.StringPtr(instanceID),
+				ID:         core.StringPtr(destinationID16),
+				Type:       core.StringPtr("spf"),
+			}
+
+			spfResult, response, err := eventNotificationsService.UpdateVerifyDestination(customSpfUpdateDestinationOptions)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(spfResult).ToNot(BeNil())
+
+			customDkimUpdateDestinationOptions := &eventnotificationsv1.UpdateVerifyDestinationOptions{
+				InstanceID: core.StringPtr(instanceID),
+				ID:         core.StringPtr(destinationID16),
+				Type:       core.StringPtr("dkim"),
+			}
+
+			dkimResult, response, err := eventNotificationsService.UpdateVerifyDestination(customDkimUpdateDestinationOptions)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(dkimResult).ToNot(BeNil())
+
 			//
 			// The following status codes aren't covered by tests.
 			// Please provide integration tests for these too.

--- a/eventnotificationsv1/event_notifications_v1_test.go
+++ b/eventnotificationsv1/event_notifications_v1_test.go
@@ -4833,6 +4833,231 @@ var _ = Describe(`EventNotificationsV1`, func() {
 			})
 		})
 	})
+	Describe(`UpdateVerifyDestination(updateVerifyDestinationOptions *UpdateVerifyDestinationOptions) - Operation response error`, func() {
+		updateVerifyDestinationPath := "/v1/instances/testString/destinations/testString/verify"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateVerifyDestinationPath))
+					Expect(req.Method).To(Equal("PATCH"))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"testString"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke UpdateVerifyDestination with error: Operation response processing error`, func() {
+				eventNotificationsService, serviceErr := eventnotificationsv1.NewEventNotificationsV1(&eventnotificationsv1.EventNotificationsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(eventNotificationsService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateVerifyDestinationOptions model
+				updateVerifyDestinationOptionsModel := new(eventnotificationsv1.UpdateVerifyDestinationOptions)
+				updateVerifyDestinationOptionsModel.InstanceID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.ID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Type = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := eventNotificationsService.UpdateVerifyDestination(updateVerifyDestinationOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				eventNotificationsService.EnableRetries(0, 0)
+				result, response, operationErr = eventNotificationsService.UpdateVerifyDestination(updateVerifyDestinationOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateVerifyDestination(updateVerifyDestinationOptions *UpdateVerifyDestinationOptions)`, func() {
+		updateVerifyDestinationPath := "/v1/instances/testString/destinations/testString/verify"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateVerifyDestinationPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"testString"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "verification": "Verification"}`)
+				}))
+			})
+			It(`Invoke UpdateVerifyDestination successfully with retries`, func() {
+				eventNotificationsService, serviceErr := eventnotificationsv1.NewEventNotificationsV1(&eventnotificationsv1.EventNotificationsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(eventNotificationsService).ToNot(BeNil())
+				eventNotificationsService.EnableRetries(0, 0)
+
+				// Construct an instance of the UpdateVerifyDestinationOptions model
+				updateVerifyDestinationOptionsModel := new(eventnotificationsv1.UpdateVerifyDestinationOptions)
+				updateVerifyDestinationOptionsModel.InstanceID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.ID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Type = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := eventNotificationsService.UpdateVerifyDestinationWithContext(ctx, updateVerifyDestinationOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				eventNotificationsService.DisableRetries()
+				result, response, operationErr := eventNotificationsService.UpdateVerifyDestination(updateVerifyDestinationOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = eventNotificationsService.UpdateVerifyDestinationWithContext(ctx, updateVerifyDestinationOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateVerifyDestinationPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"testString"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"type": "Type", "verification": "Verification"}`)
+				}))
+			})
+			It(`Invoke UpdateVerifyDestination successfully`, func() {
+				eventNotificationsService, serviceErr := eventnotificationsv1.NewEventNotificationsV1(&eventnotificationsv1.EventNotificationsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(eventNotificationsService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := eventNotificationsService.UpdateVerifyDestination(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the UpdateVerifyDestinationOptions model
+				updateVerifyDestinationOptionsModel := new(eventnotificationsv1.UpdateVerifyDestinationOptions)
+				updateVerifyDestinationOptionsModel.InstanceID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.ID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Type = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = eventNotificationsService.UpdateVerifyDestination(updateVerifyDestinationOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke UpdateVerifyDestination with error: Operation validation and request error`, func() {
+				eventNotificationsService, serviceErr := eventnotificationsv1.NewEventNotificationsV1(&eventnotificationsv1.EventNotificationsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(eventNotificationsService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateVerifyDestinationOptions model
+				updateVerifyDestinationOptionsModel := new(eventnotificationsv1.UpdateVerifyDestinationOptions)
+				updateVerifyDestinationOptionsModel.InstanceID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.ID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Type = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := eventNotificationsService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := eventNotificationsService.UpdateVerifyDestination(updateVerifyDestinationOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the UpdateVerifyDestinationOptions model with no property values
+				updateVerifyDestinationOptionsModelNew := new(eventnotificationsv1.UpdateVerifyDestinationOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = eventNotificationsService.UpdateVerifyDestination(updateVerifyDestinationOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke UpdateVerifyDestination successfully`, func() {
+				eventNotificationsService, serviceErr := eventnotificationsv1.NewEventNotificationsV1(&eventnotificationsv1.EventNotificationsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(eventNotificationsService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateVerifyDestinationOptions model
+				updateVerifyDestinationOptionsModel := new(eventnotificationsv1.UpdateVerifyDestinationOptions)
+				updateVerifyDestinationOptionsModel.InstanceID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.ID = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Type = core.StringPtr("testString")
+				updateVerifyDestinationOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := eventNotificationsService.UpdateVerifyDestination(updateVerifyDestinationOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`CreateTagsSubscription(createTagsSubscriptionOptions *CreateTagsSubscriptionOptions) - Operation response error`, func() {
 		createTagsSubscriptionPath := "/v1/instances/testString/destinations/testString/tag_subscriptions"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
@@ -8523,6 +8748,22 @@ var _ = Describe(`EventNotificationsV1`, func() {
 				Expect(updateSubscriptionOptionsModel.Description).To(Equal(core.StringPtr("testString")))
 				Expect(updateSubscriptionOptionsModel.Attributes).To(Equal(subscriptionUpdateAttributesModel))
 				Expect(updateSubscriptionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewUpdateVerifyDestinationOptions successfully`, func() {
+				// Construct an instance of the UpdateVerifyDestinationOptions model
+				instanceID := "testString"
+				id := "testString"
+				typeVar := "testString"
+				updateVerifyDestinationOptionsModel := eventNotificationsService.NewUpdateVerifyDestinationOptions(instanceID, id, typeVar)
+				updateVerifyDestinationOptionsModel.SetInstanceID("testString")
+				updateVerifyDestinationOptionsModel.SetID("testString")
+				updateVerifyDestinationOptionsModel.SetType("testString")
+				updateVerifyDestinationOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(updateVerifyDestinationOptionsModel).ToNot(BeNil())
+				Expect(updateVerifyDestinationOptionsModel.InstanceID).To(Equal(core.StringPtr("testString")))
+				Expect(updateVerifyDestinationOptionsModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(updateVerifyDestinationOptionsModel.Type).To(Equal(core.StringPtr("testString")))
+				Expect(updateVerifyDestinationOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewDestinationConfigOneOfChromeDestinationConfig successfully`, func() {
 				apiKey := "testString"


### PR DESCRIPTION
Signed-off-by: nitish <nitish.kulkarni3@ibm.com>

## PR summary
adds support for adding custom domain email as a destination

**Fixes:** <! --[ link to issue](https://github.ibm.com/notification-hub/planning/issues/9287) -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Go Commit Message Guidelines](https://github.com/IBM/ibm-cloud-sdk-common/blob/main/CONTRIBUTING_go.md#commit-messages).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
do not have support for custom domain email

## What is the new behavior?  
adds support for adding custom domain email as destination

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->