### PR TITLE
chore: smtp response fix

### DIFF
--- a/eventnotificationsv1/event_notifications_v1.go
+++ b/eventnotificationsv1/event_notifications_v1.go
@@ -7380,8 +7380,8 @@ func UnmarshalSMTPAllowedIPs(m map[string]json.RawMessage, result interface{}) (
 
 // SMTPConfig : Payload describing a SMTP configuration.
 type SMTPConfig struct {
-	// The DKIM attributes.
-	Dkim *DkimAttributes `json:"dkim,omitempty"`
+	// The SMTP DKIM attributes.
+	Dkim *SmtpdkimAttributes `json:"dkim,omitempty"`
 
 	// The en_authorization attributes.
 	EnAuthorization *EnAuthAttributes `json:"en_authorization,omitempty"`
@@ -7393,7 +7393,7 @@ type SMTPConfig struct {
 // UnmarshalSMTPConfig unmarshals an instance of SMTPConfig from the specified map of raw messages.
 func UnmarshalSMTPConfig(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(SMTPConfig)
-	err = core.UnmarshalModel(m, "dkim", &obj.Dkim, UnmarshalDkimAttributes)
+	err = core.UnmarshalModel(m, "dkim", &obj.Dkim, UnmarshalSmtpdkimAttributes)
 	if err != nil {
 		return
 	}
@@ -7582,6 +7582,37 @@ func UnmarshalSMTPCreateResponse(m map[string]json.RawMessage, result interface{
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// SmtpdkimAttributes : The SMTP DKIM attributes.
+type SmtpdkimAttributes struct {
+	// DMIM text name.
+	TxtName *string `json:"txt_name,omitempty"`
+
+	// DMIM text value.
+	TxtValue *string `json:"txt_value,omitempty"`
+
+	// DKIM verification.
+	Verification *string `json:"verification,omitempty"`
+}
+
+// UnmarshalSmtpdkimAttributes unmarshals an instance of SmtpdkimAttributes from the specified map of raw messages.
+func UnmarshalSmtpdkimAttributes(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(SmtpdkimAttributes)
+	err = core.UnmarshalPrimitive(m, "txt_name", &obj.TxtName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "txt_value", &obj.TxtValue)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "verification", &obj.Verification)
 	if err != nil {
 		return
 	}

--- a/eventnotificationsv1/event_notifications_v1_examples_test.go
+++ b/eventnotificationsv1/event_notifications_v1_examples_test.go
@@ -1934,7 +1934,7 @@ var _ = Describe(`EventNotificationsV1 Examples Tests`, func() {
 
 		It(`UpdateTemplate request example`, func() {
 			fmt.Println("\nUpdateTemplate() result:")
-			// begin-update_template
+			// begin-replace_template
 			name := "template invitation"
 			description := "template invitation description"
 			templateTypeInvitation := "smtp_custom.invitation"
@@ -2021,7 +2021,7 @@ var _ = Describe(`EventNotificationsV1 Examples Tests`, func() {
 			Expect(templateResponse.Name).To(Equal(core.StringPtr(name)))
 			Expect(templateResponse.Description).To(Equal(core.StringPtr(description)))
 
-			// end-update_template
+			// end-replace_template
 		})
 
 		It(`CreateSubscription request example`, func() {

--- a/eventnotificationsv1/event_notifications_v1_integration_test.go
+++ b/eventnotificationsv1/event_notifications_v1_integration_test.go
@@ -3261,6 +3261,9 @@ var _ = Describe(`EventNotificationsV1 Integration Tests`, func() {
 			Expect(smtpConfig.Name).To(Equal(core.StringPtr(name)))
 			Expect(smtpConfig.Description).To(Equal(core.StringPtr(description)))
 			Expect(smtpConfig.Domain).To(Equal(core.StringPtr(domain)))
+			Expect(smtpConfig.Config.Dkim).ToNot(BeNil())
+			Expect(smtpConfig.Config.Spf).ToNot(BeNil())
+			Expect(smtpConfig.Config.EnAuthorization).ToNot(BeNil())
 			smtpConfigID = *smtpConfig.ID
 		})
 	})
@@ -3386,6 +3389,9 @@ var _ = Describe(`EventNotificationsV1 Integration Tests`, func() {
 			Expect(smtpConfiguration.Domain).ToNot(BeNil())
 			Expect(smtpConfiguration.Name).ToNot(BeNil())
 			Expect(smtpConfiguration.Description).ToNot(BeNil())
+			Expect(smtpConfiguration.Config.Dkim).ToNot(BeNil())
+			Expect(smtpConfiguration.Config.Spf).ToNot(BeNil())
+			Expect(smtpConfiguration.Config.EnAuthorization).ToNot(BeNil())
 		})
 	})
 

--- a/eventnotificationsv1/event_notifications_v1_test.go
+++ b/eventnotificationsv1/event_notifications_v1_test.go
@@ -9597,7 +9597,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "created_at": "2019-01-01T12:00:00.000Z"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "created_at": "2019-01-01T12:00:00.000Z"}`)
 				}))
 			})
 			It(`Invoke CreateSMTPConfiguration successfully with retries`, func() {
@@ -9670,7 +9670,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "created_at": "2019-01-01T12:00:00.000Z"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "created_at": "2019-01-01T12:00:00.000Z"}`)
 				}))
 			})
 			It(`Invoke CreateSMTPConfiguration successfully`, func() {
@@ -9846,7 +9846,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"total_count": 10, "offset": 6, "limit": 5, "smtp_configurations": [{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}], "first": {"href": "Href"}, "previous": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"total_count": 10, "offset": 6, "limit": 5, "smtp_configurations": [{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}], "first": {"href": "Href"}, "previous": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListSMTPConfigurations successfully with retries`, func() {
@@ -9906,7 +9906,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"total_count": 10, "offset": 6, "limit": 5, "smtp_configurations": [{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}], "first": {"href": "Href"}, "previous": {"href": "Href"}, "next": {"href": "Href"}}`)
+					fmt.Fprintf(res, "%s", `{"total_count": 10, "offset": 6, "limit": 5, "smtp_configurations": [{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}], "first": {"href": "Href"}, "previous": {"href": "Href"}, "next": {"href": "Href"}}`)
 				}))
 			})
 			It(`Invoke ListSMTPConfigurations successfully`, func() {
@@ -10064,9 +10064,9 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					res.WriteHeader(200)
 					requestNumber++
 					if requestNumber == 1 {
-						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"smtp_configurations":[{"id":"ID","name":"Name","description":"Description","domain":"Domain","config":{"dkim":{"public_key":"PublicKey","selector":"Selector","verification":"Verification"},"en_authorization":{"verification":"Verification"},"spf":{"txt_name":"TxtName","txt_value":"TxtValue","verification":"Verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}`)
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"smtp_configurations":[{"id":"ID","name":"Name","description":"Description","domain":"Domain","config":{"dkim":{"txt_name":"TxtName","txt_value":"TxtValue","verification":"Verification"},"en_authorization":{"verification":"Verification"},"spf":{"txt_name":"TxtName","txt_value":"TxtValue","verification":"Verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}`)
 					} else if requestNumber == 2 {
-						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"smtp_configurations":[{"id":"ID","name":"Name","description":"Description","domain":"Domain","config":{"dkim":{"public_key":"PublicKey","selector":"Selector","verification":"Verification"},"en_authorization":{"verification":"Verification"},"spf":{"txt_name":"TxtName","txt_value":"TxtValue","verification":"Verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}`)
+						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"smtp_configurations":[{"id":"ID","name":"Name","description":"Description","domain":"Domain","config":{"dkim":{"txt_name":"TxtName","txt_value":"TxtValue","verification":"Verification"},"en_authorization":{"verification":"Verification"},"spf":{"txt_name":"TxtName","txt_value":"TxtValue","verification":"Verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}`)
 					} else {
 						res.WriteHeader(400)
 					}
@@ -10797,7 +10797,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
 				}))
 			})
 			It(`Invoke GetSMTPConfiguration successfully with retries`, func() {
@@ -10852,7 +10852,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
 				}))
 			})
 			It(`Invoke GetSMTPConfiguration successfully`, func() {
@@ -11032,7 +11032,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
 				}))
 			})
 			It(`Invoke UpdateSMTPConfiguration successfully with retries`, func() {
@@ -11105,7 +11105,7 @@ var _ = Describe(`EventNotificationsV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"public_key": "PublicKey", "selector": "Selector", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "name": "Name", "description": "Description", "domain": "Domain", "config": {"dkim": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}, "en_authorization": {"verification": "Verification"}, "spf": {"txt_name": "TxtName", "txt_value": "TxtValue", "verification": "Verification"}}, "updated_at": "2019-01-01T12:00:00.000Z"}`)
 				}))
 			})
 			It(`Invoke UpdateSMTPConfiguration successfully`, func() {


### PR DESCRIPTION
## PR summary
SMTP configuration get and list response DKIM attributes txt_name and txt_value were not coming. 

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/13951

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Go Commit Message Guidelines](https://github.com/IBM/ibm-cloud-sdk-common/blob/main/CONTRIBUTING_go.md#commit-messages).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
SMTP configuration get and list response DKIM attributes txt_name and txt_value are not coming. 

## What is the new behavior?  
SMTP configuration get and list response has DKIM attributes with txt_name and txt_value.  

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->