### PR TITLE
fix: correct module name in GetComponentInfo

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -85,5 +85,5 @@ func GetSystemInfo() string {
 
 func GetComponentInfo() *core.ProblemComponent {
 	// This should match the module name in go.mod.
-	return core.NewProblemComponent("github.ibm.com/CloudEngineering/go-sdk-template", Version)
+	return core.NewProblemComponent("github.com/IBM/event-notifications-go-admin-sdk", Version)
 }


### PR DESCRIPTION
PR summary:
  GetComponentInfo was returning the template module name instead of the actual module name defined in
  go.mod. This caused incorrect component identification in SDK error reporting.